### PR TITLE
Add sonar property to consume Gosec report

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For a Go project, create a `sonar-project.properties` file at the top of the rep
     sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**
     sonar.go.tests.reportPaths=report.json
     sonar.go.coverage.reportPaths=coverage.out
+    sonar.externalIssuesReportPaths=gosec.json
 
 This template is in this repo as the file `sonar-project.properties.go.example`.
 


### PR DESCRIPTION
Gosec runs a security scan against Go code, and allows the output to be formatted for SonarQube/SonarCloud. This entry will set it up to consume the report from the build.