### PR TITLE
Make sure any failure fails the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,10 @@ jobs:
       name: "Build the test image, push it, check potential leaked credentials and check image security scan status"
       script:
         - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
-        - |
-          make
-          make component/build
-          make component/push
-          make security/scans
+        - make
+        - make component/build
+        - make component/push
+        - make security/scans
     - stage: unit-test
       name: "Run unit tests"
       if: type = pull_request
@@ -50,25 +49,22 @@ jobs:
         # Set the image tag differently for PRs
         - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
         # Bootstrap the build harness, pull test image, and run unit tests.  
-        - | 
-          make 
-          make component/pull 
-          make component/test/unit
-          sonar-scanner --debug
+        - make 
+        - make component/pull 
+        - make component/test/unit
+        - sonar-scanner --debug
     - stage: test-e2e
       name: "Deploy the image to a cluster and run e2e tests"
       if: type = pull_request
       script:
         #Check out a clusterpool, set up oc, deploy, run e2e tests, and return clusterpool cluster
         - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
-        - |
-          make 
-          make component/pull 
-          make component/test/e2e
+        - make 
+        - make component/pull 
+        - make component/test/e2e
     - stage: publish
       name: "Publish the image to quay with an official version/sha tag and publish entry to integration pipeline stage"
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script:
-        - |
-          make 
-          make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
+        - make 
+        - make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
After adding Sonar to my repositories, I found unit test failures were not failing the build because that line was not last in the multiline script.

Separating out each script line means they all run sequentially regardless of failures, but any failure will fail the build. Open to other approaches as well, but this is a serious issue, and I think we need to open a cross-squad issue once this is updated in the example so that everyone is aware of this potential.